### PR TITLE
CI: build & push image to GitHub registry

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -3,20 +3,43 @@ name: Nix
 on:
   push:
 
+env:
+  REGISTRY_USER: ${{ github.actor }}
+  REGISTRY_PASSWORD: ${{ github.token }}
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  image_name: gtvm-hs
+  image_tag: ${{ github.sha }}
+
 jobs:
   nix-build:
-    name: nix build .#${{ matrix.ghc }}-gtvm-hs
-    strategy:
-      fail-fast: false
-      matrix:
-        ghc: [ghc910, ghc96]
+    name: nix build .#ghc910-gtvm-hs-image; push image
     runs-on: ubuntu-latest
     permissions:
-      id-token: "write"
-      contents: "read"
+      packages: write # for pushing to image registry
+      #id-token: write # ? requested by magic-nix-cache
+      #contents: read # ? requested by magic-nix-cache
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: DeterminateSystems/magic-nix-cache-action@main
     - uses: DeterminateSystems/flake-checker-action@main
-    - run: nix build .#${{ matrix.ghc }}-gtvm-hs
+
+    - run: nix build .#ghc910-gtvm-hs
+
+    - run: nix build .#ghc910-gtvm-hs-image
+    - run: ./result | podman load
+
+    - uses: redhat-actions/podman-login@v1
+      with:
+        username: ${{ env.REGISTRY_USER }}
+        password: ${{ env.REGISTRY_PASSWORD }}
+        registry: ${{ env.IMAGE_REGISTRY }}
+
+    # 2023-06-28: redhat-actions/push-to-registry doesn't let you qualify your
+    # target image, so it's pretty much useless. lmao
+    # https://github.com/redhat-actions/push-to-registry/issues/66
+    # still true as of 2024-10-05... guys...
+
+    # your repo needs write permission to push to the registry for this to work!
+    # configured in Packages (tab at user/org level)
+    - run: 'podman push localhost/${{ env.image_name }}:${{ env.image_tag }} ${{ env.IMAGE_REGISTRY }}/${{ env.image_name }}:${{ env.image_tag }}'

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -15,7 +15,7 @@ jobs:
     name: nix build .#ghc910-gtvm-hs-image; push image
     runs-on: ubuntu-latest
     permissions:
-      packages: write # for pushing to image registry
+      packages: write # for pushing to container registry
       #id-token: write # ? requested by magic-nix-cache
       #contents: read # ? requested by magic-nix-cache
     steps:
@@ -41,5 +41,11 @@ jobs:
     # still true as of 2024-10-05... guys...
 
     # your repo needs write permission to push to the registry for this to work!
-    # configured in Packages (tab at user/org level)
+    # unsure how to configure. maybe in Packages tab at user/org level?
+    # maybe job permissions is good enough? (seemed to work here)
+    # the built image is expected to be tagged with `${{ env.image_tag }}`;
+    # push to that, and `${{ github.ref_name }}` (= tag, else branch)
+    # unsure how this works with fork PRs-- probably write permissions fail.
+    # light TODO.
     - run: 'podman push localhost/${{ env.image_name }}:${{ env.image_tag }} ${{ env.IMAGE_REGISTRY }}/${{ env.image_name }}:${{ env.image_tag }}'
+    - run: 'podman push localhost/${{ env.image_name }}:${{ env.image_tag }} ${{ env.IMAGE_REGISTRY }}/${{ env.image_name }}:${{ github.ref_name }}'

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
           packages.strongweak.source = inputs.strongweak;
         };
 
-        packages.gtvm-hs-image-ghc910 = pkgs.dockerTools.streamLayeredImage {
+        packages.ghc910-gtvm-hs-image = pkgs.dockerTools.streamLayeredImage {
           name = "gtvm-hs";
           # `git rev-parse HEAD` on clean, "dev" on dirty
           tag = inputs.self.rev or "dev";


### PR DESCRIPTION
Build and push image to commit hash, and tag name (or branch).

Disabled GHC 9.6 CI build for simplicity (and to not waste CI cycles.)